### PR TITLE
Added dotenv to load env variables

### DIFF
--- a/cua-server/package.json
+++ b/cua-server/package.json
@@ -5,6 +5,7 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts"
   },
   "dependencies": {
+    "dotenv": "^16.5.0",
     "socket.io": "^4.8.1",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",

--- a/cua-server/src/index.ts
+++ b/cua-server/src/index.ts
@@ -1,5 +1,10 @@
+import dotenv from "dotenv";
 import http from "http";
 import { Server as SocketIOServer, Socket } from "socket.io";
+
+
+// Load environment variables first
+dotenv.config();
 
 import { handleTestCaseInitiated } from "./handlers/test-case-initiation-handler";
 import { handleSocketMessage } from "./handlers/user-messages-handler";


### PR DESCRIPTION
Lack of loading env variables caused the following issue when cua-server is started:
(Unless it was set in the terminal. But README mentions .env.example -> .env.development for this so when you follow the steps on README this is the issue you run into)

```
[dev:cua-server] [INFO] 13:52:28 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.2, typescript ver. 5.8.3)
[dev:cua-server] Error: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }).
[dev:cua-server]     at new OpenAI (/Users/yusuf.erdogan/work/temp/openai-testing-agent-demo/node_modules/openai/src/index.ts:272:13)
[dev:cua-server]     at Object.<anonymous> (/Users/yusuf.erdogan/work/temp/openai-testing-agent-demo/cua-server/src/agents/test-case-agent.ts:19:16)
[dev:cua-server]     at Module._compile (node:internal/modules/cjs/loader:1529:14)
[dev:cua-server]     at Module._compile (/Users/yusuf.erdogan/work/temp/openai-testing-agent-demo/node_modules/source-map-support/source-map-support.js:568:25)
[dev:cua-server]     at Module.m._compile (/private/var/folders/jx/1r0mjc6d3fnbsggzq2kgn92r7m702k/T/ts-node-dev-hook-19603066960508797.js:69:33)
[dev:cua-server]     at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)
[dev:cua-server]     at require.extensions..jsx.require.extensions..js (/private/var/folders/jx/1r0mjc6d3fnbsggzq2kgn92r7m702k/T/ts-node-dev-hook-19603066960508797.js:114:20)
[dev:cua-server]     at require.extensions.<computed> (/private/var/folders/jx/1r0mjc6d3fnbsggzq2kgn92r7m702k/T/ts-node-dev-hook-19603066960508797.js:71:20)
[dev:cua-server]     at Object.nodeDevHook [as .ts] (/Users/yusuf.erdogan/work/temp/openai-testing-agent-demo/node_modules/ts-node-dev/lib/hook.js:63:13)
[dev:cua-server]     at Module.load (node:internal/modules/cjs/loader:1275:32)
[dev:cua-server] [ERROR] 13:52:29 Error: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }).
```