### PR TITLE
fix: cua-server should load .env.development

### DIFF
--- a/cua-server/package.json
+++ b/cua-server/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts"
+    "dev": "ts-node-dev --env-file=.env.development --respawn --transpile-only src/index.ts"
   },
   "dependencies": {
     "socket.io": "^4.8.1",


### PR DESCRIPTION
### Before

The app works with a global `OPENAI_API_KEY`, but fails without it:


```console

> dev
> concurrently "npm:dev:sample-test-app" "npm:dev:frontend" "npm:dev:cua-server"

[dev:sample-test-app] 
[dev:sample-test-app] > dev:sample-test-app
[dev:sample-test-app] > npm run dev --prefix sample-test-app
[dev:sample-test-app] 
[dev:cua-server] 
[dev:cua-server] > dev:cua-server
[dev:cua-server] > npm run dev --prefix cua-server
[dev:cua-server] 
[dev:frontend] 
[dev:frontend] > dev:frontend
[dev:frontend] > npm run dev --prefix frontend
[dev:frontend] 
[dev:sample-test-app] 
[dev:sample-test-app] > sample-test-app@0.1.0 dev
[dev:sample-test-app] > next dev --turbopack -p 3005
[dev:sample-test-app] 
[dev:cua-server] 
[dev:cua-server] > dev
[dev:cua-server] > ts-node-dev --respawn --transpile-only src/index.ts
[dev:cua-server] 
[dev:frontend] 
[dev:frontend] > automated-testing-agent-demo@0.1.0 dev
[dev:frontend] > next dev
[dev:frontend] 
[dev:cua-server] [INFO] 14:17:56 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.2, typescript ver. 5.8.3)
[dev:cua-server] Error: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }).
[dev:cua-server]     at new OpenAI (/Users/eric/Projects/ericclemmons/openai-testing-agent-demo/node_modules/openai/src/index.ts:272:13)
[dev:cua-server]     at Object.<anonymous> (/Users/eric/Projects/ericclemmons/openai-testing-agent-demo/cua-server/src/agents/test-case-agent.ts:19:16)
[dev:cua-server]     at Module.<anonymous> (node:internal/modules/cjs/loader:1734:14)
[dev:cua-server]     at Module._compile (/Users/eric/Projects/ericclemmons/openai-testing-agent-demo/node_modules/source-map-support/source-map-support.js:568:25)
[dev:cua-server]     at Module.m._compile (/private/var/folders/4w/_l20wtfj41n2dx0xyhb8xd740000gn/T/ts-node-dev-hook-615071896034732.js:69:33)
[dev:cua-server]     at loadTS (node:internal/modules/cjs/loader:1826:10)
[dev:cua-server]     at require.extensions.<computed> (/private/var/folders/4w/_l20wtfj41n2dx0xyhb8xd740000gn/T/ts-node-dev-hook-615071896034732.js:71:20)
[dev:cua-server]     at Object.nodeDevHook [as .ts] (/Users/eric/Projects/ericclemmons/openai-testing-agent-demo/node_modules/ts-node-dev/lib/hook.js:63:13)
[dev:cua-server]     at Module.load (node:internal/modules/cjs/loader:1469:32)
[dev:cua-server]     at Module._load (node:internal/modules/cjs/loader:1286:12)
[dev:cua-server] [ERROR] 14:17:56 Error: The OPENAI_API_KEY environment variable is missing or empty; either provide it, or instantiate the OpenAI client with an apiKey option, like new OpenAI({ apiKey: 'My API Key' }).
[dev:frontend]    ▲ Next.js 15.3.3
[dev:frontend]    - Local:        http://localhost:3000
[dev:frontend]    - Network:      http://192.168.1.158:3000
[dev:frontend]    - Environments: .env.development
[dev:frontend] 
[dev:frontend]  ✓ Starting...
[dev:cua-server] [14:17:56.890] INFO (76192): Logger initialized with log level: info
^C[dev:sample-test-app] 
[dev:cua-server] npm run dev:cua-server exited with code SIGINT
[dev:sample-test-app] npm run dev:sample-test-app exited with code 0
[dev:frontend] 
[dev:frontend] npm run dev:frontend exited with code 0
```

### After

Since the instructions explicitly tell the user to `cp .env .env.development`, this PR makes the app work out-of-the-box

```console

> dev
> concurrently "npm:dev:sample-test-app" "npm:dev:frontend" "npm:dev:cua-server"

[dev:cua-server] 
[dev:cua-server] > dev:cua-server
[dev:cua-server] > npm run dev --prefix cua-server
[dev:cua-server] 
[dev:sample-test-app] 
[dev:sample-test-app] > dev:sample-test-app
[dev:sample-test-app] > npm run dev --prefix sample-test-app
[dev:sample-test-app] 
[dev:frontend] 
[dev:frontend] > dev:frontend
[dev:frontend] > npm run dev --prefix frontend
[dev:frontend] 
[dev:frontend] 
[dev:frontend] > automated-testing-agent-demo@0.1.0 dev
[dev:frontend] > next dev
[dev:frontend] 
[dev:cua-server] 
[dev:cua-server] > dev
[dev:cua-server] > ts-node-dev --env-file=.env.development --respawn --transpile-only src/index.ts
[dev:cua-server] 
[dev:sample-test-app] 
[dev:sample-test-app] > sample-test-app@0.1.0 dev
[dev:sample-test-app] > next dev --turbopack -p 3005
[dev:sample-test-app] 
[dev:cua-server] [INFO] 14:19:28 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.2, typescript ver. 5.8.3)
[dev:frontend]    ▲ Next.js 15.3.3
[dev:frontend]    - Local:        http://localhost:3000
[dev:frontend]    - Network:      http://192.168.1.158:3000
[dev:frontend]    - Environments: .env.development
[dev:frontend] 
[dev:frontend]  ✓ Starting...
[dev:sample-test-app]    ▲ Next.js 15.3.1 (Turbopack)
[dev:sample-test-app]    - Local:        http://localhost:3005
[dev:sample-test-app]    - Network:      http://192.168.1.158:3005
[dev:sample-test-app]    - Environments: .env.development
[dev:sample-test-app] 
[dev:sample-test-app]  ✓ Starting...
[dev:cua-server] [14:19:28.209] INFO (77138): Logger initialized with log level: info
[dev:cua-server] [14:19:28.551] INFO (77138): Socket.IO server listening on port 8000
[dev:cua-server] [14:19:28.551] INFO (77138): CORS origin: *
[dev:sample-test-app]  ✓ Ready in 789ms
[dev:frontend]  ✓ Ready in 1172ms
```
