### PR TITLE
fix: Configure test variables form (UI tweaks)

### DIFF
--- a/frontend/components/ConfigPanel.tsx
+++ b/frontend/components/ConfigPanel.tsx
@@ -183,7 +183,7 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                   </CardDescription>
                 </CardHeader>
 
-                <CardContent className="space-y-6 max-h-[42vh] overflow-y-auto">
+                <CardContent className="space-y-6 max-h-[42vh] overflow-y-auto pt-1">
                   {/* URL */}
                   <div className="flex items-center gap-3">
                     <Label
@@ -263,7 +263,7 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                     {/* User info */}
 
                     <div className="space-y-3">
-                      <Label htmlFor="requires-login">User info</Label>
+                      <Label>User info</Label>
 
                       <div className="flex gap-6 items-center">
                         <div className="flex items-center gap-2">
@@ -282,6 +282,7 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                             value={name}
                             onChange={(e) => setName(e.target.value)}
                             className="flex-1"
+                            disabled={submitting}
                           />
                         </div>
                         <div className="flex flex-1 items-center gap-2">
@@ -300,6 +301,7 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                             value={email}
                             onChange={(e) => setEmail(e.target.value)}
                             className="flex-1"
+                            disabled={submitting}
                           />
                         </div>
                       </div>
@@ -318,7 +320,7 @@ export default function ConfigPanel({ onSubmitted }: ConfigPanelProps) {
                           placeholder="123 Main St, Anytown, USA"
                           value={address}
                           onChange={(e) => setAddress(e.target.value)}
-                          disabled={submitting || !requiresLogin}
+                          disabled={submitting}
                           className="flex-1"
                         />
                       </div>


### PR DESCRIPTION
### Fixed issues : 

- **Clipped URL input field:** The URL input appeared clipped due to insufficient spacing between its container and the element above, causing the top border to be partially hidden.
<img width="439" height="419" alt="url" src="https://github.com/user-attachments/assets/63696591-9cfc-46cf-91e1-da285b536277" />

- **Incorrect label linkage:** The "User info" label was incorrectly linked to the `requires-login` switch via `htmlFor="requires-login"`, causing the switch to toggle when the label was clicked.
- **Improper address field disabling:** The address input was being disabled based on the `requiresLogin` flag, even though there's no logical connection between them. This incorrectly prevented editing when `requiresLogin` was false.

<img width="415" height="248" alt="Screenshot 2025-07-11 104044" src="https://github.com/user-attachments/assets/665ab51a-909f-4eea-a3b4-b85292a656c8" />

- **Missing field disabling on submit:** The Name and Email fields were not disabled during form submission, allowing changes mid-submit.
